### PR TITLE
Added permission set

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ All you need to do is then to push this package's sources by typing:
 sfdx force:source:push -u <scratch org's alias / username>
 ```
 
+Assign the GitHubAppUser permission set to the default user:
+
+```sh
+sfdx force:user:permset:assign -n GitHubAppUser
+```
+
 If you want to have sample data for Case objects, you may import it with:
 
 ```sh

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,5 +1,5 @@
 {
-  "orgName": "SFDC Github Authenticator",
+  "orgName": "SFDC GitHub Authenticator",
   "edition": "Developer",
   "features": [],
   "language": "en_US",

--- a/force-app/main/default/applications/GitHub.app-meta.xml
+++ b/force-app/main/default/applications/GitHub.app-meta.xml
@@ -9,7 +9,7 @@
         <pageOrSobjectType>standard-home</pageOrSobjectType>
     </actionOverrides>
     <brand>
-        <headerColor>#0070D2</headerColor>
+        <headerColor>#000000</headerColor>
         <logo>githubicon</logo>
         <logoVersion>1</logoVersion>
         <shouldOverrideOrgTheme>true</shouldOverrideOrgTheme>
@@ -20,70 +20,6 @@
     <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
     <label>GitHub</label>
     <navType>Standard</navType>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Customer Portal Manager Custom</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Customer Portal Manager Standard</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Customer Community User</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>External Identity User</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Force.com - App Subscription User</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Force.com - Free User</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>Gold Partner User</profile>
-    </profileActionOverrides>
-    <profileActionOverrides>
-        <actionName>Tab</actionName>
-        <content>Home</content>
-        <formFactor>Large</formFactor>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-        <type>Flexipage</type>
-        <profile>HighVolumePortal</profile>
-    </profileActionOverrides>
     <profileActionOverrides>
         <actionName>Tab</actionName>
         <content>Home</content>
@@ -323,6 +259,70 @@
         <pageOrSobjectType>standard-home</pageOrSobjectType>
         <type>Flexipage</type>
         <profile>Customer Community Plus User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Customer Portal Manager Custom</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Customer Portal Manager Standard</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Customer Community User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>External Identity User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Force.com - App Subscription User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Force.com - Free User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Gold Partner User</profile>
+    </profileActionOverrides>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>Home</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>HighVolumePortal</profile>
     </profileActionOverrides>
     <tabs>standard-home</tabs>
     <tabs>GitHub_Repos__x</tabs>

--- a/force-app/main/default/authproviders/Github.authprovider-meta.xml
+++ b/force-app/main/default/authproviders/Github.authprovider-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuthProvider xmlns="http://soap.sforce.com/2006/04/metadata">
-    <friendlyName>Github</friendlyName>
+    <friendlyName>GitHub</friendlyName>
     <includeOrgIdInIdentifier>false</includeOrgIdInIdentifier>
     <providerType>GitHub</providerType>
     <sendAccessTokenInHeader>true</sendAccessTokenInHeader>

--- a/force-app/main/default/classes/ApiUtils.cls
+++ b/force-app/main/default/classes/ApiUtils.cls
@@ -1,5 +1,5 @@
 public with sharing class ApiUtils {
-    public static String apiUrlToGithub(String rawString){
+    public static String apiUrlToGitHub(String rawString){
         if (rawString == null) return null;
         return rawString.replaceFirst('api.github.com/repos','github.com');
     }

--- a/force-app/main/default/classes/IssueDataModel.cls
+++ b/force-app/main/default/classes/IssueDataModel.cls
@@ -53,8 +53,8 @@ public with sharing class IssueDataModel {
 
         issue.put('DisplayUrl', issue.get('url'));
 
-        issue.put('RepositoryURL', ApiUtils.apiUrlToGithub((String)issue.get('repository_url')));
-        issue.put('IssueURL', ApiUtils.apiUrlToGithub((String)issue.get('url')));
+        issue.put('RepositoryURL', ApiUtils.apiUrlToGitHub((String)issue.get('repository_url')));
+        issue.put('IssueURL', ApiUtils.apiUrlToGitHub((String)issue.get('url')));
 
         issue.put('Number', issue.get('number'));
 

--- a/force-app/main/default/classes/PullRequestDataModel.cls
+++ b/force-app/main/default/classes/PullRequestDataModel.cls
@@ -51,7 +51,7 @@ public class PullRequestDataModel {
 
         pullRequest.put('DisplayUrl', pullRequest.get('url'));
 
-        pullRequest.put('PullRequestURL', ApiUtils.apiUrlToGithub((String)pullRequest.get('url')));
+        pullRequest.put('PullRequestURL', ApiUtils.apiUrlToGitHub((String)pullRequest.get('url')));
 
         pullRequest.put('Draft', pullRequest.get('draft'));
 

--- a/force-app/main/default/lwc/casesList/casesList.html
+++ b/force-app/main/default/lwc/casesList/casesList.html
@@ -1,10 +1,10 @@
 <template>
     <lightning-card title="My Open Cases" icon-name="standard:case">
-        <div class="slds-m-around_medium">    
+        <div class="slds-var-m-around_medium">    
             <lightning-datatable
-            data={cases.data}
-            columns={columns}
-            key-field="id">
+                data={cases.data}
+                columns={columns}
+                key-field="id">
             </lightning-datatable>
         </div>
     </lightning-card>

--- a/force-app/main/default/lwc/gitHubReposList/gitHubReposList.html
+++ b/force-app/main/default/lwc/gitHubReposList/gitHubReposList.html
@@ -1,12 +1,11 @@
 <template>
-    <lightning-card title="My Github Repositories" icon-name="custom:custom55">
-        <div class="slds-m-around_medium" style="height: 310px;">    
-
-        <lightning-datatable
+    <lightning-card title="My GitHub Repositories" icon-name="custom:custom55">
+        <div class="slds-var-m-around_medium" style="height: 310px;">    
+            <lightning-datatable
                 data={gitHubRepos.data}
                 columns={columns}
                 key-field="id">
-        </lightning-datatable>
+            </lightning-datatable>
         </div>
     </lightning-card>
 </template>

--- a/force-app/main/default/namedCredentials/GitHubCredentials.namedCredential-meta.xml
+++ b/force-app/main/default/namedCredentials/GitHubCredentials.namedCredential-meta.xml
@@ -2,7 +2,7 @@
 <NamedCredential xmlns="http://soap.sforce.com/2006/04/metadata">
     <allowMergeFieldsInBody>false</allowMergeFieldsInBody>
     <allowMergeFieldsInHeader>false</allowMergeFieldsInHeader>
-    <authProvider>Github</authProvider>
+    <authProvider>GitHub</authProvider>
     <endpoint>https://api.github.com/</endpoint>
     <generateAuthorizationHeader>true</generateAuthorizationHeader>
     <label>GitHubCredentials</label>

--- a/force-app/main/default/permissionsets/GitHubAppUser.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/GitHubAppUser.permissionset-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>GitHub</application>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>GitHub App User</label>
+</PermissionSet>

--- a/install-dev.bat
+++ b/install-dev.bat
@@ -22,6 +22,11 @@ cmd.exe /c sfdx force:source:push -f -u %ORG_ALIAS%
 call :checkForError
 @echo:
 
+echo Assigning permissions...
+cmd.exe /c sfdx force:user:permset:assign -n GitHubAppUser -u %ORG_ALIAS%
+call :checkForError
+@echo:
+
 rem Check exit code
 @echo:
 if ["%errorlevel%"]==["0"] (

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -21,6 +21,10 @@ echo "Pushing source..." && \
 sfdx force:source:push -u $ORG_ALIAS && \
 echo "" && \
 
+echo "Assigning permission sets..." && \
+sfdx force:user:permset:assign -n GitHubAppUser -u $ORG_ALIAS && \
+echo "" && \
+
 echo "Opening sample app..." && \
 sfdx force:org:open -u $ORG_ALIAS
 EXIT_CODE="$?"


### PR DESCRIPTION
Setup instructions do not grant access to the GitHub Lightning app.
I created a permission set that allows that and I referenced in readme and install scripts.

Some additional minor changes:
- Fixed a typo in GitHub spelling (it was missing a capital H in some instances).
- Renamed the GitHub app from "lizards"