### PR TITLE
User-friendly field labels and descriptions

### DIFF
--- a/force-app/main/default/objects/GitHub_Issues__x/fields/AssigneeId__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/AssigneeId__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>AssigneeId__c</fullName>
-    <description>AssigneeId</description>
+    <description>Assignee Id</description>
     <externalDeveloperName>AssigneeId</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>AssigneeId</label>
+    <label>Assignee Id</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/ClosedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/ClosedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ClosedDate__c</fullName>
-    <description>ClosedDate</description>
+    <description>Closed Date</description>
     <externalDeveloperName>ClosedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>ClosedDate</label>
+    <label>Closed Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/CreatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/CreatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>CreatedDate__c</fullName>
-    <description>CreatedDate</description>
+    <description>Created Date</description>
     <externalDeveloperName>CreatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>CreatedDate</label>
+    <label>Created Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/IssueURL__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/IssueURL__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IssueURL__c</fullName>
-    <description>IssueURL</description>
+    <description>Issue URL</description>
     <externalDeveloperName>IssueURL</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>IssueURL</label>
+    <label>Issue URL</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/OwnerId__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/OwnerId__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OwnerId__c</fullName>
-    <description>OwnerId</description>
+    <description>Owner Id</description>
     <externalDeveloperName>OwnerId</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>OwnerId</label>
+    <label>Owner Id</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/PullRequest__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/PullRequest__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>PullRequest__c</fullName>
-    <description>PullRequest</description>
+    <description>Pull Request</description>
     <externalDeveloperName>PullRequest</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>PullRequest</label>
+    <label>Pull Request</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/RepositoryId__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/RepositoryId__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepositoryId__c</fullName>
-    <description>RepositoryId</description>
+    <description>Repository Id</description>
     <externalDeveloperName>RepositoryId</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepositoryId</label>
+    <label>Repository Id</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/RepositoryURL__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/RepositoryURL__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepositoryURL__c</fullName>
-    <description>RepositoryURL</description>
+    <description>Repository URL</description>
     <externalDeveloperName>RepositoryURL</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepositoryURL</label>
+    <label>Repository URL</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Issues__x/fields/UpdatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Issues__x/fields/UpdatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UpdatedDate__c</fullName>
-    <description>UpdatedDate</description>
+    <description>Updated Date</description>
     <externalDeveloperName>UpdatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>UpdatedDate</label>
+    <label>Updated Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/ClosedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/ClosedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ClosedDate__c</fullName>
-    <description>ClosedDate</description>
+    <description>Closed Date</description>
     <externalDeveloperName>ClosedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>ClosedDate</label>
+    <label>Closed Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/CreatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/CreatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>CreatedDate__c</fullName>
-    <description>CreatedDate</description>
+    <description>Created Date</description>
     <externalDeveloperName>CreatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>CreatedDate</label>
+    <label>Created Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/MergedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/MergedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>MergedDate__c</fullName>
-    <description>MergedDate</description>
+    <description>Merged Date</description>
     <externalDeveloperName>MergedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>MergedDate</label>
+    <label>Merged Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PRCreatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PRCreatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>PRCreatedDate__c</fullName>
-    <description>PRCreatedDate</description>
+    <description>PR Created Date</description>
     <externalDeveloperName>PRCreatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>PRCreatedDate</label>
+    <label>PR Created Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PRUpdatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PRUpdatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>PRUpdatedDate__c</fullName>
-    <description>PRUpdatedDate</description>
+    <description>PR Updated Date</description>
     <externalDeveloperName>PRUpdatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>PRUpdatedDate</label>
+    <label>PR Updated Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PullRequestURL__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/PullRequestURL__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>PullRequestURL__c</fullName>
-    <description>PullRequestURL</description>
+    <description>Pull Request URL</description>
     <externalDeveloperName>PullRequestURL</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>PullRequestURL</label>
+    <label>Pull Request URL</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/RepoName__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/RepoName__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepoName__c</fullName>
-    <description>RepoName</description>
+    <description>Repo Name</description>
     <externalDeveloperName>RepoName</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepoName</label>
+    <label>Repo Name</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/UpdatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Pull_Requests__x/fields/UpdatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UpdatedDate__c</fullName>
-    <description>UpdatedDate</description>
+    <description>Updated Date</description>
     <externalDeveloperName>UpdatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>UpdatedDate</label>
+    <label>Updated Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/LanguagesUrl__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/LanguagesUrl__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LanguagesUrl__c</fullName>
-    <description>LanguagesUrl</description>
+    <description>Languages URL</description>
     <externalDeveloperName>LanguagesUrl</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>LanguagesUrl</label>
+    <label>Languages URL</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/LastPushedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/LastPushedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LastPushedDate__c</fullName>
-    <description>LastPushedDate</description>
+    <description>Last Pushed Date</description>
     <externalDeveloperName>LastPushedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>LastPushedDate</label>
+    <label>Last Pushed Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/OpenIssuesCount__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/OpenIssuesCount__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OpenIssuesCount__c</fullName>
-    <description>OpenIssuesCount</description>
+    <description>Open Issues Count</description>
     <externalDeveloperName>OpenIssuesCount</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>OpenIssuesCount</label>
+    <label>Open Issues Count</label>
     <precision>16</precision>
     <required>false</required>
     <scale>0</scale>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/OwnerLogin__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/OwnerLogin__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OwnerLogin__c</fullName>
-    <description>OwnerLogin</description>
+    <description>Owner Login</description>
     <externalDeveloperName>OwnerLogin</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>OwnerLogin</label>
+    <label>Owner Login</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/RepoCreatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/RepoCreatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepoCreatedDate__c</fullName>
-    <description>RepoCreatedDate</description>
+    <description>Repo Created Date</description>
     <externalDeveloperName>RepoCreatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepoCreatedDate</label>
+    <label>Repo Created Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/RepoUpdatedDate__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/RepoUpdatedDate__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepoUpdatedDate__c</fullName>
-    <description>RepoUpdatedDate</description>
+    <description>Repo Updated Date</description>
     <externalDeveloperName>RepoUpdatedDate</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepoUpdatedDate</label>
+    <label>Repo Updated Date</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/RepositoryURL__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/RepositoryURL__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RepositoryURL__c</fullName>
-    <description>RepositoryURL</description>
+    <description>Repository URL</description>
     <externalDeveloperName>RepositoryURL</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>RepositoryURL</label>
+    <label>Repository URL</label>
     <required>false</required>
     <type>Url</type>
 </CustomField>

--- a/force-app/main/default/objects/GitHub_Repos__x/fields/TotalForks__c.field-meta.xml
+++ b/force-app/main/default/objects/GitHub_Repos__x/fields/TotalForks__c.field-meta.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TotalForks__c</fullName>
-    <description>TotalForks</description>
+    <description>Total Forks</description>
     <externalDeveloperName>TotalForks</externalDeveloperName>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>TotalForks</label>
+    <label>Total Forks</label>
     <precision>16</precision>
     <required>false</required>
     <scale>0</scale>


### PR DESCRIPTION
Introduced spaces in field labels and descriptions to make them user-friendly.
Developer names are untouched so that nothing breaks.